### PR TITLE
Add KG4ESG: The ESG Knowledge Graph Atlas (Applications → ESG/Sustainability)

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,3 +200,6 @@ for Complex Reasoning (Arxiv, 2023) [[paper]](https://arxiv.org/pdf/2301.08913.p
 
 ### Fault Analysis
 * Tele-Knowledge Pre-training for Fault Analysis (ICDE, 2023) [[paper]](https://arxiv.org/abs/2210.11298)
+
+### ESG / Sustainability
+* KG4ESG: The ESG Knowledge Graph Atlas (Preprints, 2026) [[paper]](https://www.preprints.org/manuscript/202602.1970)


### PR DESCRIPTION
Adds **KG4ESG: The ESG Knowledge Graph Atlas** to **Applications**, as a new **ESG / Sustainability** domain subsection (matching the per-domain structure of Recommender System / Fault Analysis).

KG4ESG is an LLM-augmented knowledge graph atlas for the Environmental, Social, and Governance (ESG) domain — integrating ESG standards, frameworks, and entities (an LLM-for-KG construction application).

Link: https://www.preprints.org/manuscript/202602.1970 (preprint)

Follows the `* Title (Venue, Year) [[paper]](url)` format.